### PR TITLE
README.md 中 valaxy.config.ts 配置代码修复

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For detailed configuration and explanations, see [Theme Configuration](https://s
 import { defineConfig } from 'valaxy'
 import type { ThemeUserConfig } from 'valaxy-theme-sakura'
 
-export default defineValaxyConfig<ThemeUserConfig>({
+export default defineConfig<ThemeUserConfig>({
   theme: 'sakura',
 
   themeConfig: {

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -50,7 +50,7 @@ pnpm add valaxy-theme-sakura
 import { defineConfig } from 'valaxy'
 import type { ThemeUserConfig } from 'valaxy-theme-sakura'
 
-export default defineValaxyConfig<ThemeUserConfig>({
+export default defineConfig<ThemeUserConfig>({
   theme: 'sakura',
 
   themeConfig: {


### PR DESCRIPTION
README.md 中给出的 valaxy.config.ts 示例中, import 与 export 的变量名不相同,导致Valaxy无法正确读取配置文件,修改后可以正常应用主题