### PR TITLE
Update SakuraPostCardInfo.vue 更正卡片信息的更新日期

### DIFF
--- a/theme/components/SakuraPostCardInfo.vue
+++ b/theme/components/SakuraPostCardInfo.vue
@@ -8,7 +8,7 @@ defineProps<{
 
 <template>
   <div class="sakura-post-card-info">
-    <SakuraPostDate :date="post.date" class="post-date order-1" pb-4 text-sm />
+    <SakuraPostDate :date="post.updated" class="post-date order-1" pb-4 text-sm />
     <SakuraPostTitle pb-4 class="order-2" :title="post.title" :to="post.path" />
     <SakuraPostMeta pb-2 class="order-3" :post />
     <SakuraPostExcerpt v-if="post?.excerpt" pb-2 class="order-4" :excerpt="post.excerpt" />


### PR DESCRIPTION
组件SakuraPostCardInfo.vue中传递的日期为post.date而不是post.updated，导致卡片信息的更新日期实际显示为发表日期，更正后更新日期正常显示