### PR TITLE
fix(archives): resolve duplicate posts when top is set

### DIFF
--- a/theme/components/SakuraTimeLine.vue
+++ b/theme/components/SakuraTimeLine.vue
@@ -1,7 +1,8 @@
 <script lang="ts" setup>
 import type { Post } from 'valaxy'
 import { formatDate, sortByDate } from 'valaxy'
-import { computed, ref, watch } from 'vue'
+// 引入 reactive 以支持展开状态的响应式追踪
+import { computed, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const props = defineProps<{
@@ -14,41 +15,45 @@ const isDesc = ref(true)
 const years = ref<number[]>([])
 const months = ref<Record<string, number[]>>({})
 const postListByYear = ref<Record<string, Record<string, Post[]>>>({})
-const originalPostListByYear = ref<Record<string, Record<string, Post[]>>>({})
-const lockedMonths = ref<Record<string, boolean>>({})
-const hoverTimeouts = ref<Record<string, ReturnType<typeof setTimeout>>>({})
+
+// 替代 originalPostListByYear，记录 hover 时展开的月份
+const expandedMonths = reactive<Record<string, boolean>>({})
 
 watch(() => props.posts, () => {
   postListByYear.value = {}
   years.value = []
   months.value = {}
-  lockedMonths.value = {}
-  hoverTimeouts.value = {}
-  props.posts.forEach((post) => {
-    if (post.hide && post.hide !== 'index')
-      return
-    if (post.date) {
-      const year = Number.parseInt(formatDate(post.date, { template: 'YYYY' }))
-      const month = Number.parseInt(formatDate(post.date, { template: 'MM' }))
-      if (!postListByYear.value[year]) {
-        years.value.push(year)
-        months.value[year] = []
-        postListByYear.value[year] = {}
-      }
-      if (!postListByYear.value[year][month]) {
-        months.value[year].push(month)
-        postListByYear.value[year][month] = []
-      }
-      postListByYear.value[year][month].push(post)
-    }
-  })
-  originalPostListByYear.value = JSON.parse(JSON.stringify(postListByYear.value))
 
-  Object.keys(postListByYear.value).forEach((year) => {
-    Object.keys(postListByYear.value[year]).forEach((month) => {
-      postListByYear.value[year][month] = []
+  Object.keys(expandedMonths).forEach(k => delete expandedMonths[k])
+
+  // 浅拷贝后按 date 纯时间排序，消除 top 对归档分组的干扰
+  ;[...props.posts]
+    .sort((a, b) => {
+      const da = a.date ? +new Date(a.date) : 0
+      const db = b.date ? +new Date(b.date) : 0
+      return db - da
     })
-  })
+    .forEach((post) => {
+      if (post.hide && post.hide !== 'index')
+        return
+      if (post.date) {
+        const year = Number.parseInt(formatDate(post.date, 'yyyy'))
+        const month = Number.parseInt(formatDate(post.date, 'MM'))
+        if (!postListByYear.value[year]) {
+          years.value.push(year)
+          months.value[year] = []
+          postListByYear.value[year] = {}
+        }
+        if (postListByYear.value[year][month]) {
+          postListByYear.value[year][month].push(post)
+        }
+        else {
+          months.value[year].push(month)
+          // 每篇文章只入一次，月份头与文章条目在模板中解耦
+          postListByYear.value[year][month] = [post]
+        }
+      }
+    })
 }, { immediate: true })
 
 const sortedYears = computed(() => {
@@ -63,131 +68,19 @@ function sortedMonths(year: number) {
   return isDesc.value ? arr : arr.reverse()
 }
 
+// 将 year/month 编码为唯一的展开状态 key
+function monthKey(year: number, month: number) {
+  return `${year}-${month}`
+}
+
+// 判断某月是否已展开
+function isExpanded(year: number, month: number) {
+  return !!expandedMonths[monthKey(year, month)]
+}
+
+// hover 时展开该月文章列表
 function handleMouseEnter(year: number, month: number) {
-  const key = `${year}-${month}`
-  if (hoverTimeouts.value[key]) {
-    clearTimeout(hoverTimeouts.value[key])
-    delete hoverTimeouts.value[key]
-  }
-
-  if (lockedMonths.value[key])
-    return
-
-  if (postListByYear.value[year][month].length === 0)
-    postListByYear.value[year][month] = [...originalPostListByYear.value[year][month]]
-}
-
-function handleMouseLeave(year: number, month: number) {
-  const key = `${year}-${month}`
-  if (lockedMonths.value[key])
-    return
-
-  hoverTimeouts.value[key] = setTimeout(() => {
-    postListByYear.value[year][month] = []
-    delete hoverTimeouts.value[key]
-  }, 300)
-}
-
-function handleMonthClick(year: number, month: number) {
-  const key = `${year}-${month}`
-
-  if (hoverTimeouts.value[key]) {
-    clearTimeout(hoverTimeouts.value[key])
-    delete hoverTimeouts.value[key]
-  }
-
-  if (lockedMonths.value[key]) {
-    // If already locked, unlock it and collapse
-    delete lockedMonths.value[key]
-    postListByYear.value[year][month] = []
-  }
-  else {
-    // Lock it and expand
-    lockedMonths.value[key] = true
-    postListByYear.value[year][month] = [...originalPostListByYear.value[year][month]]
-  }
-}
-
-function isYearActive(year: number) {
-  if (!months.value[year])
-    return false
-  return months.value[year].every(month => lockedMonths.value[`${year}-${month}`])
-}
-
-function handleYearDoubleClick(year: number) {
-  const yearMonths = months.value[year] || []
-  const allLocked = yearMonths.every(m => lockedMonths.value[`${year}-${m}`])
-
-  yearMonths.forEach((month) => {
-    const key = `${year}-${month}`
-
-    // Clear any pending timeouts
-    if (hoverTimeouts.value[key]) {
-      clearTimeout(hoverTimeouts.value[key])
-      delete hoverTimeouts.value[key]
-    }
-
-    if (allLocked) {
-      // Unlock all
-      delete lockedMonths.value[key]
-      postListByYear.value[year][month] = []
-    }
-    else {
-      // Lock all
-      lockedMonths.value[key] = true
-      postListByYear.value[year][month] = [...originalPostListByYear.value[year][month]]
-    }
-  })
-}
-
-function onBeforeEnter(el: Element) {
-  const element = el as HTMLElement
-  element.style.opacity = '0'
-  element.style.height = '0'
-  // Use visible to allow overflow content (like the circle indicator) to be seen
-  // But we need hidden for the height transition to work properly for the content
-  // A common trick is to wrap content or handle padding
-  element.style.overflow = 'hidden'
-}
-
-function onEnter(el: Element, done: () => void) {
-  const element = el as HTMLElement
-  // Trigger reflow
-
-  element.offsetHeight
-
-  element.style.transitionProperty = 'height, opacity'
-  element.style.transitionDuration = '0.5s'
-  element.style.transitionTimingFunction = 'ease'
-
-  element.style.opacity = '1'
-  element.style.height = `${element.scrollHeight}px`
-  // Allow overflow during animation if possible, or adjust padding
-  // If we set overflow visible here, the height animation might look weird if content spills out
-  // But for the circle on the left, we can ensure the container has enough padding-left
-
-  element.addEventListener('transitionend', () => {
-    element.style.height = ''
-    element.style.overflow = 'visible' // Ensure overflow is visible after animation
-    done()
-  }, { once: true })
-}
-
-function onLeave(el: Element, done: () => void) {
-  const element = el as HTMLElement
-  element.style.transitionProperty = 'height, opacity'
-  element.style.transitionDuration = '0.5s'
-  element.style.transitionTimingFunction = 'ease'
-
-  element.style.overflow = 'hidden'
-  element.style.height = `${element.scrollHeight}px`
-  // Force reflow
-
-  element.offsetHeight
-
-  element.style.opacity = '0'
-  element.style.height = '0'
-  element.addEventListener('transitionend', done, { once: true })
+  expandedMonths[monthKey(year, month)] = true
 }
 </script>
 
@@ -204,79 +97,62 @@ function onLeave(el: Element, done: () => void) {
       </button>
     </div>
 
-    <TransitionGroup name="year-list" tag="div">
-      <div v-for="year in sortedYears" :key="year" class="ml-1/3">
-        <div class="collection-title relative">
-          <h2
-            :id="`#archive-year-${year}`"
-            class="archive-year ml--8 cursor-pointer select-none"
-            :class="{ active: isYearActive(year) }"
-            text="2xl"
-            @dblclick="handleYearDoubleClick(year)"
+    <div v-for="year in sortedYears" :key="year" class="ml-1/3">
+      <h2 :id="`#archive-year-${year}`" class="archive-year ml--8" text="2xl">
+        {{ year }}年
+      </h2>
+      <template v-for="month in sortedMonths(year)" :key="month">
+        <TransitionGroup name="timeline" tag="ul" class="relative p-0" @mouseenter="handleMouseEnter(year, month)">
+          <!-- 月份头：始终可见 -->
+          <li
+            :key="`month-${year}-${month}`"
+            class="post-item relative"
           >
-            {{ year }}年
-          </h2>
-        </div>
-        <TransitionGroup name="month-list" tag="div">
-          <template v-for="month in sortedMonths(year)" :key="month">
-            <TransitionGroup
-              name="post-list"
-              tag="ul"
-              class="relative p-0 pl-4"
-              @mouseenter="handleMouseEnter(year, month)"
-              @mouseleave="handleMouseLeave(year, month)"
-              @before-enter="onBeforeEnter"
-              @enter="onEnter"
-              @leave="onLeave"
+            <header
+              class="post-header circle-indicator h-$sakura-timeline-height"
+              flex items-center
             >
-              <li
-                :key="`month-${year}-${month}`"
-                class="month-item month-indicator post-item relative cursor-pointer"
-                :class="{ active: postListByYear[year][month]?.length > 0 }"
-                @click="handleMonthClick(year, month)"
+              <div class="post-meta absolute right-100% my-[1rem] mr-[1.2rem]">
+                <time class="post-time" font="mono" opacity="80">
+                  {{ formatDate(postListByYear[year][month][0].date, 'MM') }}月
+                </time>
+                <span class="text-$sakura-color-text">
+                  ({{ postListByYear[year][month].length }} 篇文章)
+                </span>
+              </div>
+            </header>
+          </li>
+
+          <!-- 文章条目：hover 时展开 -->
+          <template v-if="isExpanded(year, month)">
+            <li
+              v-for="post, j in sortByDate(postListByYear[year][month], isDesc)"
+              :key="`post-${year}-${month}-${j}`"
+              class="post-item relative"
+            >
+              <header
+                class="post-header hover-indicator h-$sakura-timeline-height"
+                flex items-center
               >
-                <div class="month-meta absolute right-100% my-[1rem] mr-[1.2rem] whitespace-nowrap">
-                  <time class="post-time" font="mono" opacity="80">{{ month.toString().padStart(2, '0') }}月</time>
-                  <span class="text-$sakura-color-text"> ({{ originalPostListByYear[year][month].length }} 篇文章)</span>
+                <div class="post-meta my-[1rem] ml-[1.2rem]">
+                  <time v-if="post.date" class="post-time text-$sakura-timeline-text-color" font="mono" opacity="80">{{ formatDate(post.date, 'dd') }}日
+                  </time>
+                  <h2 class="post-title" inline-flex items-center font="serif black">
+                    <RouterLink :to="post.path || ''" class="post-title-link text-$sakura-color-text hover:text-$sakura-color-action">
+                      {{ post.title }}
+                    </RouterLink>
+                  </h2>
                 </div>
-                <div class="h-10" />
-              </li>
-              <li
-                v-for="post, j in sortByDate(postListByYear[year][month], isDesc)"
-                :key="`post-${year}-${month}-${j}`"
-                class="post-item relative"
-                :style="{ transitionDelay: `${j * 0.05}s` }"
-              >
-                <header
-                  class="post-header day-indicator h-$sakura-timeline-height" flex items-center
-                >
-                  <div class="post-meta my-[1rem] ml-[1.2rem]">
-                    <time v-if="post.date" class="post-time text-$sakura-timeline-text-color" font="mono" opacity="80">{{
-                      formatDate(post.date, { template: 'DD' }) }}日
-                    </time>
-                    <h2 class="post-title" inline-flex items-center font="serif black">
-                      <RouterLink :to="post.path || ''" class="post-title-link text-$sakura-color-text hover:text-$sakura-color-action">
-                        {{ post.title }}
-                      </RouterLink>
-                    </h2>
-                  </div>
-                </header>
-              </li>
-            </TransitionGroup>
+              </header>
+            </li>
           </template>
         </TransitionGroup>
-      </div>
-    </TransitionGroup>
+      </template>
+    </div>
   </div>
 </template>
 
 <style lang="scss" scoped>
-.year-list-move,
-.month-list-move,
-.post-list-move {
-  transition: transform 0.8s cubic-bezier(0.35, 0, 0.25, 1);
-}
-
 .timeline-move,
 .timeline-enter-active,
 .timeline-leave-active {
@@ -288,13 +164,13 @@ function onLeave(el: Element, done: () => void) {
 .timeline-enter-from,
 .timeline-leave-to {
   opacity: 0;
-  transform: translateY(20px);
+  transform: scaleY(0) translateX(40px);
 }
 
 .timeline-enter-to,
 .timeline-leave-from {
   opacity: 1;
-  transform: translateY(0);
+  transform: scaleY(1) translateX(0);
 }
 
 .timeline-leave-active {
@@ -302,48 +178,36 @@ function onLeave(el: Element, done: () => void) {
 }
 
 .post-collapse {
-  // &::before {
-  //   content: '';
-  //   position: absolute;
-  //   top: 50%;
-  //   width: 2px;
-  //   height: 50%;
-  //   background: var(--sakura-color-primary);
-  // }
-
-  .archive-year {
-    transition: color 0.3s ease;
-    user-select: none;
-
-    &.active {
-      color: var(--sakura-color-primary);
-
-      // &::before {
-      //   background: white;
-      //   border: 3px solid var(--sakura-color-primary);
-      //   box-shadow: 0 0 0 2px var(--sakura-color-primary);
-      // }
+  .collection-title {
+    &::before {
+      content: '';
+      position: absolute;
+      top: 50%;
+      width: 2px;
+      height: 50%;
+      background: var(--sakura-color-primary);
     }
 
-    // &::before {
-    //   content: '';
-    //   position: absolute;
-    //   left: 0;
-    //   top: 35%;
-    //   margin-left: -7px;
-    //   margin-top: 14px;
-    //   width: 1rem;
-    //   height: 1rem;
-    //   background: var(--sakura-color-primary);
-    //   border-radius: 50%;
-    //   transition: all 0.3s ease;
-    // }
+    .archive-year {
+      color: var(--sakura-timeline-color);
+      margin: 0 1.5rem;
+
+      &::before {
+        content: '';
+        position: absolute;
+        left: 0;
+        top: 35%;
+        margin-left: -7px;
+        margin-top: 14px;
+        width: 1rem;
+        height: 1rem;
+        background: var(--sakura-color-primary);
+        border-radius: 50%;
+      }
+    }
   }
 
   .post-item {
-    margin-left: -1rem; /* Revert the pl-4 added to ul to align text back */
-    padding-left: 1rem;
-
     &::before {
       content: '';
       position: absolute;
@@ -351,13 +215,10 @@ function onLeave(el: Element, done: () => void) {
       height: 100%;
       box-sizing: border-box;
       background: var(--sakura-timeline-color);
-      left: 1rem; /* Adjust line position to match new padding */
     }
   }
 
   .post-header {
-    // border-bottom: 1px solid rgba(var(--va-c-primary-rgb), 0.3);
-
     .post-title {
       margin-left: 0.1rem;
       padding: 0;
@@ -379,11 +240,11 @@ function onLeave(el: Element, done: () => void) {
   }
 }
 
-.day-indicator {
-  &::after {
+.hover-indicator {
+  &::before {
     content: '';
     position: absolute;
-    left: 1rem;
+    left: 0;
     width: 10px;
     height: 10px;
     margin-left: -4px;
@@ -395,33 +256,23 @@ function onLeave(el: Element, done: () => void) {
   }
 
   &:hover {
-    &::after {
+    &::before {
       background: var(--sakura-timeline-color);
     }
   }
 }
 
-.month-indicator {
-  &::after {
-    content: '';
-    position: absolute;
-    left: 1rem;
-    top: 35%;
-    margin-left: -9px;
-    width: 1.2rem;
-    height: 1.2rem;
-    background: var(--sakura-timeline-color);
-    border-radius: 50%;
-    border: 3px solid white;
-    box-shadow: 0 0 0 1px var(--sakura-timeline-color);
-    z-index: 1;
-    transition: all 0.3s ease;
-  }
-
-  &.active::after {
-    background: white;
-    border: 5px solid var(--sakura-timeline-color);
-    box-shadow: 0 0 0 2px var(--sakura-timeline-color);
-  }
+.circle-indicator::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 35%;
+  margin-left: -7px;
+  width: 1rem;
+  height: 1rem;
+  background: var(--sakura-timeline-color);
+  border-radius: 50%;
+  border: 2px solid white;
+  box-shadow: 1px 1px 1px var(--sakura-color-divider);
 }
 </style>


### PR DESCRIPTION
**Description**
Fixes a bug where setting `top` in frontmatter caused the article to appear twice in the archives page (also reproducible on the [official demo site](https://sakura.wrxinyue.org/archives)).

**Root cause**
The original code "double-pushed" the first article of each month into `postListByYear` to reuse it as both the month header (`j === 0`) and the first article entry (`j > 0`). When `top` changed the sort order, the wrong article was chosen as the "first" of a given month, leading to duplication and missing articles.

**Fix**

* Decoupled month headers from article entries in the template into separate `<li>` elements.
* Replaced `originalPostListByYear` deep clone with `expandedMonths` (reactive Record/Object) to track UI state.
* Sorted posts by pure date in `watch` to prevent `top` from disrupting chronological grouping.

---

**描述**
修复了在 frontmatter 中设置 `top` 后导致文章在归档页面重复显示的问题（该问题在[官方演示站点](https://sakura.wrxinyue.org/archives)上亦可复现）。

**根本原因**
原代码将每个月的第一篇文章"双次推送"到 `postListByYear` 中，以复用它同时作为月份标题（`j === 0`）和第一篇正文条目（`j > 0`）。当 `top` 改变了排序顺序后，某个月份中被选为"第一篇"的文章就不正确了，从而导致文章重复和吞噬。

**修复方案**

* 在模板中将月份标题与正文条目彻底解耦，拆分为独立的 `<li>` 元素。
* 用 `expandedMonths`（响应式字典/对象）替换了 `originalPostListByYear` 深拷贝，仅用于追踪 UI 展开状态。
* 在 `watch` 中按纯物理日期排序文章，防止 `top` 权重干扰时间分组顺序。

<img width="1227" height="1140" alt="20260618" src="https://github.com/user-attachments/assets/4b6cb58a-36b2-46dd-9d0c-986d48da4816" />
